### PR TITLE
restless manager: add app argument to create_api

### DIFF
--- a/project/api/views.py
+++ b/project/api/views.py
@@ -7,11 +7,12 @@ from ..extensions import manager
 
 
 def initialize_api(app):
-    # List all Flask-Restless APIs here
-    # model_api = manager.create_api(MyModel, methods=['GET'],
-    #                                app=app,
-    #                                url_prefix='/api')
-    pass
+    with app.app_context():
+        # List all Flask-Restless APIs here
+        # model_api = manager.create_api(MyModel, methods=['GET'],
+        #                                app=app,
+        #                                url_prefix='/api')
+        pass
 
 
 api = Blueprint('api', __name__)

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -6,10 +6,12 @@ from ..extensions import manager
 # from ..models import MyModel
 
 
-def initialize_api():
+def initialize_api(app):
     # List all Flask-Restless APIs here
-    # model_api = manager.create_api(MyModel, methods=['GET'])
+    # model_api = manager.create_api(MyModel, methods=['GET'],
+    #                                app=app,
+    #                                url_prefix='/api')
     pass
 
 
-api = Blueprint('api', __name__, url_prefix='/api')
+api = Blueprint('api', __name__)

--- a/project/app.py
+++ b/project/app.py
@@ -44,7 +44,7 @@ def create_app(config=None, app_name='project', blueprints=None):
 
     blueprints_fabrics(app, blueprints)
     extensions_fabrics(app)
-    api_fabrics()  # this must be called after extensions_fabrics
+    api_fabrics(api)  # this must be called after extensions_fabrics
     configure_logging(app)
 
     error_pages(app)
@@ -79,15 +79,15 @@ def extensions_fabrics(app):
     pages.init_app(app)
     init_social(app, db)
     login_manager.init_app(app)
-    manager.init_app(app, db)
+    manager.init_app(app, flask_sqlalchemy_db=db)
     migrate.init_app(app, db)
     csrf.init_app(app)
     cache.init_app(app)
     celery.config_from_object(app.config)
 
 
-def api_fabrics():
-    initialize_api()
+def api_fabrics(app):
+    initialize_api(app)
 
 
 def error_pages(app):


### PR DESCRIPTION
Due to https://github.com/jfinkels/flask-restless/issues/313 app argument should be passed directly to create_api method, init_app will not store app object. Same for url_prefix.